### PR TITLE
[Resolves #8] Diary 대표 이미지 접근 (redirect)

### DIFF
--- a/src/main/java/grimuri/backend/domain/diary/Diary.java
+++ b/src/main/java/grimuri/backend/domain/diary/Diary.java
@@ -4,6 +4,7 @@ import grimuri.backend.domain.BaseTimeEntity;
 import grimuri.backend.domain.image.Image;
 import grimuri.backend.domain.user.User;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -35,6 +36,7 @@ public class Diary extends BaseTimeEntity {
     private String shortContent;
 
     @OneToMany(mappedBy = "diary")
+    @BatchSize(size = 10)
     private List<Image> imageList = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/grimuri/backend/domain/diary/DiaryController.java
+++ b/src/main/java/grimuri/backend/domain/diary/DiaryController.java
@@ -6,13 +6,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -23,6 +22,26 @@ public class DiaryController {
 
     private final ImageService imageService;
     private final DiaryService diaryService;
+
+    /**
+     * 대표 이미지 Redirect
+     *
+     * @param diaryId 대표 이미지를 가져오려는 Diary의 Id
+     * @return
+     */
+    @GetMapping("/{diaryId}/image")
+    public ResponseEntity<?> redirectToMainImage(@PathVariable Long diaryId) {
+        // TODO: 인증로직 추가 후 userId를 통해 userSeq 가져와서 사용
+        Long userSeq = 1L;
+
+        String mainImageUrl = diaryService.getMainImageUrl(userSeq, diaryId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create(mainImageUrl));
+
+        return ResponseEntity.status(HttpStatus.PERMANENT_REDIRECT).headers(headers).body(null);
+    }
+
 
     /**
      * 로그인된 유저의 일기 목록을 페이징하여 조회함

--- a/src/main/java/grimuri/backend/domain/diary/DiaryRepository.java
+++ b/src/main/java/grimuri/backend/domain/diary/DiaryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
@@ -15,4 +16,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<Diary> findByUser(Long userSeq);
 
     Page<Diary> findByUser(Long userSeq, Pageable pageable);
+
+    Optional<Diary> findById(Long diaryId);
 }

--- a/src/main/java/grimuri/backend/domain/diary/DiaryService.java
+++ b/src/main/java/grimuri/backend/domain/diary/DiaryService.java
@@ -24,6 +24,34 @@ public class DiaryService {
     private final ImageRepository imageRepository;
 
     /**
+     * userSeq와 diaryId를 이용해 해당 diaryId의 대표 이미지 URL을 반환함.
+     * @param userSeq User의 Seq
+     * @param diaryId Diary의 Id
+     * @return String
+     */
+    public String getMainImageUrl(Long userSeq, Long diaryId) {
+        //       diaryId로 Diary 조회
+        Diary diary = diaryRepository.findById(diaryId)
+                        .orElseThrow(() -> {
+                            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "diaryId에 해당하는 Diary가 없습니다.");
+                        });
+
+        //        해당 diaryId가 userSeq의 것인지 확인
+        boolean userSeqCheck = diary.getUser().getSeq().equals(userSeq);
+        if (!userSeqCheck) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "userSeq의 Diary가 아닙니다.");
+        }
+
+        //        diaryId가 selected인지 아닌지 확인 (expected true)
+        if (!diary.getSelected()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "아직 대표 이미지가 선택되지 않았습니다.");
+        }
+
+        //        diaryId가 갖는 대표 이미지 URL 조회
+        return diary.getImageList().get(0).getSourceUrl();
+    }
+
+    /**
      *
      * @param userSeq User의 Seq
      * @param pageable Controller를 통해 입력된 Page 정보


### PR DESCRIPTION
#8
diaryId 정보와 함께 대표 이미지 액세스를 요청하면, 해당 diaryId의 대표 이미지 URL을 조회하여 Redirect 시킴.
- Diary.imageList : @BatchSize(10) 추가
- DiaryController.redirectToMainImage
- DiaryService.getMainImageUrl