### PR TITLE
[Resolves #14] Swagger를 이용하여 API Docs 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 }
 
 tasks.named('test') {

--- a/src/main/java/grimuri/backend/domain/diary/DiaryService.java
+++ b/src/main/java/grimuri/backend/domain/diary/DiaryService.java
@@ -34,7 +34,7 @@ public class DiaryService {
      * @param requestDto Diary 생성을 요청할 때 Body에 있는 값 (제목과 내용)
      * @return DiaryResponseDto.Create
      */
-    public DiaryResponseDto.Create createDiary(Long userSeq, DiaryRequestDto.Create requestDto) {
+    public DiaryResponseDto.Create createDiary(Long userSeq, DiaryRequestDto.CreateRequest requestDto) {
         User writer = userRepository.findById(userSeq).orElseThrow(() -> {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "user가 없습니다.");
         });
@@ -57,6 +57,7 @@ public class DiaryService {
      * @return String
      */
     public String getMainImageUrl(Long userSeq, Long diaryId) {
+        log.info("asdf");
         //       diaryId로 Diary 조회
         Diary diary = diaryRepository.findById(diaryId)
                         .orElseThrow(() -> {

--- a/src/main/java/grimuri/backend/domain/diary/controller/DiaryController.java
+++ b/src/main/java/grimuri/backend/domain/diary/controller/DiaryController.java
@@ -1,0 +1,121 @@
+package grimuri.backend.domain.diary.controller;
+
+import grimuri.backend.domain.diary.dto.DiaryRequestDto;
+import grimuri.backend.domain.diary.dto.DiaryResponseDto;
+import grimuri.backend.global.PageableAsParameter;
+import grimuri.backend.global.SchemaDescriptionUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import javax.validation.Valid;
+import java.util.List;
+
+public interface DiaryController {
+
+    @Operation(
+            summary = "일기 생성",
+            description = "제목(title)과 일기 내용(content)를 입력받아, Diary를 생성하고 저장한다.",
+            tags = { "DiaryController" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Created, 정상적으로 저장되었음.",
+                content = @Content(schema = @Schema(implementation = DiaryResponseDto.Create.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized, 권한 없음.",
+                content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "Not Found, 존재하지 않는 사용자임.",
+                content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error",
+                content = @Content(schema = @Schema(hidden = true)))
+    })
+    @ResponseStatus(HttpStatus.CREATED)
+    ResponseEntity<DiaryResponseDto.Create> createDiary(@RequestBody @Valid DiaryRequestDto.CreateRequest requestDto);
+
+    @Operation(
+            summary = "일기 대표 이미지 액세스",
+            description = "diaryId에 해당하는 일기의 대표 이미지 URL로 redirect 한다.",
+            tags = { "DiaryController" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "301", description = "Moved Permanently, 대표 이미지 URL로 정상 redirect 됨",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "400", description = "Bad Request, 사용자의 Diary가 아니거나, 아직 대표 이미지가 선택되지 않음",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized, 권한 없음.",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "Not Found, 존재하지 않는 사용자임.",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    @ResponseStatus(HttpStatus.MOVED_PERMANENTLY)
+    ResponseEntity<?> redirectToMainImage(
+            @Parameter(description = SchemaDescriptionUtils.Diary.diaryId, in = ParameterIn.PATH) @PathVariable Long diaryId);
+
+    @Operation(
+            summary = "일기 목록 페이지 조회",
+            description = "페이지의 항목 개수, 페이지 인덱스, ASC/DESC를 지정하여 일기 항목 페이지를 조회한다.",
+            tags = { "DiaryController" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Ok. content의 내용은 DiaryResponse 스키마를 참조.",
+                    content = @Content(schema = @Schema(implementation = Page.class, subTypes = DiaryResponseDto.DiaryResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized, 권한 없음.",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    @PageableAsParameter
+    @ResponseStatus(HttpStatus.OK)
+    ResponseEntity<Page<DiaryResponseDto.DiaryResponse>> getDiaryResponsePage(
+            @Parameter(schema = @Schema(hidden = true)) Pageable pageable);
+
+    @Operation(
+            summary = "일기 목록 전체 조회",
+            description = "페이징 없이 일기 목록 전체를 조회한다.",
+            tags = { "DiaryController" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Ok",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = DiaryResponseDto.DiaryResponse.class)))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized, 권한 없음.",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    @ResponseStatus(HttpStatus.OK)
+    ResponseEntity<List<DiaryResponseDto.DiaryResponse>> getDiaryListAll();
+
+    @Operation(
+            summary = "일기 후보 이미지 목록 조회",
+            description = "일기의 후보 이미지 목록을 조회한다.",
+            tags = { "DiaryController" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Ok",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = DiaryResponseDto.ImageUrl.class)))),
+            @ApiResponse(responseCode = "400", description = "Bad Request, 이미 대표 이미지가 선택된 Diary임",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized, 권한 없음.",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error",
+                    content = @Content(schema = @Schema(hidden = true)))
+    })
+    @ResponseStatus(HttpStatus.OK)
+    ResponseEntity<List<DiaryResponseDto.ImageUrl>> getCandidateImageList(
+            @Parameter(description = SchemaDescriptionUtils.Diary.diaryId, in = ParameterIn.PATH) @PathVariable Long diaryId);
+}

--- a/src/main/java/grimuri/backend/domain/diary/controller/DiaryControllerImpl.java
+++ b/src/main/java/grimuri/backend/domain/diary/controller/DiaryControllerImpl.java
@@ -1,5 +1,6 @@
-package grimuri.backend.domain.diary;
+package grimuri.backend.domain.diary.controller;
 
+import grimuri.backend.domain.diary.DiaryService;
 import grimuri.backend.domain.diary.dto.DiaryRequestDto;
 import grimuri.backend.domain.diary.dto.DiaryResponseDto;
 import grimuri.backend.domain.image.ImageService;
@@ -18,14 +19,15 @@ import java.util.List;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/diary")
-public class DiaryController {
+@RequestMapping("/api/v1/diary")
+public class DiaryControllerImpl implements DiaryController {
 
     private final ImageService imageService;
     private final DiaryService diaryService;
 
     @PostMapping("")
-    public ResponseEntity<DiaryResponseDto.Create> createDiary(@RequestBody DiaryRequestDto.Create requestDto) {
+    @Override
+    public ResponseEntity<DiaryResponseDto.Create> createDiary(@RequestBody DiaryRequestDto.CreateRequest requestDto) {
         // TODO: 인증로직 추가 후 userId를 통해 userSeq 가져와서 사용
         Long userSeq = 1L;
 
@@ -41,6 +43,7 @@ public class DiaryController {
      * @return
      */
     @GetMapping("/{diaryId}/image")
+    @Override
     public ResponseEntity<?> redirectToMainImage(@PathVariable Long diaryId) {
         // TODO: 인증로직 추가 후 userId를 통해 userSeq 가져와서 사용
         Long userSeq = 1L;
@@ -50,7 +53,7 @@ public class DiaryController {
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(URI.create(mainImageUrl));
 
-        return ResponseEntity.status(HttpStatus.PERMANENT_REDIRECT).headers(headers).body(null);
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).headers(headers).body(null);
     }
 
 
@@ -60,6 +63,7 @@ public class DiaryController {
      * @return Page of DiaryResponseDto.DiaryResponse
      */
     @GetMapping("")
+    @Override
     public ResponseEntity<Page<DiaryResponseDto.DiaryResponse>> getDiaryResponsePage(Pageable pageable) {
         // TODO: 인증로직 추가 후 userId를 통해 userSeq 가져와서 사용
         Long userSeq = 1L;
@@ -74,6 +78,7 @@ public class DiaryController {
      * @return List of DiaryResponseDto.DiaryResponse
      */
     @GetMapping("/all")
+    @Override
     public ResponseEntity<List<DiaryResponseDto.DiaryResponse>> getDiaryListAll() {
 
         // TODO: 인증로직 추가 후 userId를 통해 userSeq 가져와서 사용
@@ -91,6 +96,7 @@ public class DiaryController {
      * @return List of DiaryResponseDto.CandidateImageUrl
      */
     @GetMapping("/{diaryId}/images")
+    @Override
     public ResponseEntity<List<DiaryResponseDto.ImageUrl>> getCandidateImageList(@PathVariable Long diaryId) {
 
         // TODO: 인증로직 추가 후 diaryId가 사용자의 것인지 확인

--- a/src/main/java/grimuri/backend/domain/diary/dto/DiaryRequestDto.java
+++ b/src/main/java/grimuri/backend/domain/diary/dto/DiaryRequestDto.java
@@ -1,8 +1,10 @@
 package grimuri.backend.domain.diary.dto;
 
+import grimuri.backend.global.SchemaDescriptionUtils;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 
 public class DiaryRequestDto {
 
@@ -11,12 +13,15 @@ public class DiaryRequestDto {
     @AllArgsConstructor
     @Builder
     @ToString
-    public static class Create {
+    @Schema(description = "일기 생성 요청 Body")
+    public static class CreateRequest {
 
-        @NotEmpty(message = "title을 입력해주세요.")
+        @NotBlank(message = "title을 입력해주세요.")
+        @Schema(description = SchemaDescriptionUtils.Diary.title)
         private String title;
 
-        @NotEmpty(message = "content를 입력해주세요.")
+        @NotBlank(message = "content를 입력해주세요.")
+        @Schema(description = SchemaDescriptionUtils.Diary.originalContent)
         private String content;
 
     }

--- a/src/main/java/grimuri/backend/domain/diary/dto/DiaryResponseDto.java
+++ b/src/main/java/grimuri/backend/domain/diary/dto/DiaryResponseDto.java
@@ -2,6 +2,8 @@ package grimuri.backend.domain.diary.dto;
 
 import grimuri.backend.domain.diary.Diary;
 import grimuri.backend.domain.image.Image;
+import grimuri.backend.global.SchemaDescriptionUtils;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,10 +20,16 @@ public class DiaryResponseDto {
     @AllArgsConstructor
     @Builder
     @ToString
+    @Schema(description = "사용자가 생성한 일기 항목의 정보")
     public static class Create {
 
+        @Schema(description = SchemaDescriptionUtils.Diary.diaryId)
         private Long diaryId;
+
+        @Schema(description = SchemaDescriptionUtils.Diary.title)
         private String title;
+
+        @Schema(description = SchemaDescriptionUtils.Diary.originalContent)
         private String originalContent;
 
         public static Create of(Diary diary) {
@@ -37,14 +45,28 @@ public class DiaryResponseDto {
     @AllArgsConstructor
     @Builder
     @ToString
+    @Schema(description = "일기 정보")
     public static class DiaryResponse {
 
+        @Schema(description = SchemaDescriptionUtils.Diary.diaryId)
         private Long diaryId;
+
+        @Schema(description = SchemaDescriptionUtils.Diary.title)
         private String title;
+
+        @Schema(description = SchemaDescriptionUtils.Diary.originalContent)
         private String originalContent;
+
+        @Schema(description = SchemaDescriptionUtils.Diary.tags)
         private List<Tag> tags;
+
+        @Schema(description = SchemaDescriptionUtils.Diary.imageSelected)
         private Boolean imageSelected;
+
+        @Schema(description = SchemaDescriptionUtils.Diary.candidateImageUrls)
         private List<ImageUrl> candidateImageUrls;
+
+        @Schema(description = SchemaDescriptionUtils.Diary.mainImageUrl)
         private ImageUrl mainImageUrl;
 
         public static DiaryResponse imageSelectedOf(Diary diary) {
@@ -78,9 +100,13 @@ public class DiaryResponseDto {
     @AllArgsConstructor
     @Builder
     @ToString
+    @Schema(description = "일기를 요약한 결과인 Tag이다. 영어 태그와 한국어 태그로 이루어져 있다.")
     public static class Tag {
 
+        @Schema(description = SchemaDescriptionUtils.Tag.engTag)
         private String engTag;
+
+        @Schema(description = SchemaDescriptionUtils.Tag.korTag)
         private String korTag;
 
         public static Tag of(String pairStr) {
@@ -103,9 +129,13 @@ public class DiaryResponseDto {
     @AllArgsConstructor
     @Builder
     @ToString
+    @Schema(description = "이미지의 정보이다. 이미지의 id와 URL로 이루어져있다.")
     public static class ImageUrl {
 
+        @Schema(description = SchemaDescriptionUtils.ImageUrl.imageId)
         private Long imageId;
+
+        @Schema(description = SchemaDescriptionUtils.ImageUrl.imageUrl)
         private String imageUrl;
 
         public static ImageUrl of(Image image) {

--- a/src/main/java/grimuri/backend/domain/image/ImageController.java
+++ b/src/main/java/grimuri/backend/domain/image/ImageController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/image")
+@RequestMapping("/api/v1/image")
 public class ImageController {
 
 

--- a/src/main/java/grimuri/backend/domain/user/UserController.java
+++ b/src/main/java/grimuri/backend/domain/user/UserController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/user")
+@RequestMapping("/api/v1/user")
 public class UserController {
 
 

--- a/src/main/java/grimuri/backend/global/PageResponse.java
+++ b/src/main/java/grimuri/backend/global/PageResponse.java
@@ -1,0 +1,24 @@
+package grimuri.backend.global;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@Schema(description = "페이지 정보를 포함하는 응답")
+@Data
+public class PageResponse<T> {
+
+    @Schema(description = "페이지 정보")
+    private Pageable pageable;
+
+    @Schema(description = "전체 페이지 개수")
+    private int totalPages;
+
+    @Schema(description = "전체 데이터 개수")
+    private long totalElements;
+
+    @Schema(description = "현재 페이지에 포함된 데이터 리스트")
+    private List<T> content;
+}

--- a/src/main/java/grimuri/backend/global/PageableAsParameter.java
+++ b/src/main/java/grimuri/backend/global/PageableAsParameter.java
@@ -1,0 +1,36 @@
+package grimuri.backend.global;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(
+        in = ParameterIn.QUERY,
+        description = "0부터 시작하는 페이지 인덱스",
+        name = "page",
+        schema = @Schema(type = "integer", defaultValue = "0")
+)
+@Parameter(
+        in = ParameterIn.QUERY,
+        description = "페이지 하나에 나타낼 항목의 최대 크기",
+        name = "size",
+        schema = @Schema(type = "integer", defaultValue = "10")
+)
+@Parameter(
+        in = ParameterIn.QUERY,
+        description = "정렬 기준과 오름차순/내림차순.\n" +
+                "Diary에 있는 항목 중 id를 기준으로 오름차순 정렬을 한다면, \"id,ASC\"와 같이 적는다.\n" +
+                "만약 여러 항목을 기준으로 한다면, 아이템을 더 추가해서 순서대로 적는다.",
+        name = "sort",
+        array = @ArraySchema(schema = @Schema(type = "String", defaultValue = "", example = "id,ASC"))
+)
+public @interface PageableAsParameter {
+}

--- a/src/main/java/grimuri/backend/global/SchemaDescriptionUtils.java
+++ b/src/main/java/grimuri/backend/global/SchemaDescriptionUtils.java
@@ -1,0 +1,30 @@
+package grimuri.backend.global;
+
+public class SchemaDescriptionUtils {
+
+    public static class Diary {
+        public static final String diaryId = "일기 항목의 Id";
+        public static final String title = "일기의 제목";
+        public static final String originalContent = "사용자가 입력한 일기의 원문";
+        public static final String tags = "사용자가 입력한 일기의 태그 (요약)";
+        public static final String imageSelected = "일기의 대표 이미지가 선택되었는지 여부";
+        public static final String candidateImageUrls = "일기의 후보 이미지 목록. 대표 이미지가 선택되지 않았을 경우에만 존재하며," +
+                "대표 이미지가 선택된 일기의 경우 해당 항목은 빈 값이다.";
+        public static final String mainImageUrl = "일기의 대표 이미지 정보. 대표 이미지가 선택되었을 경우에만 존재하며," +
+                "대표 이미지가 선택되지 않은 경우 해당 항목은 빈 값이다.";
+
+    }
+
+    public static class Tag {
+
+        public static final String engTag = "영어 태그";
+        public static final String korTag = "한국어 태그";
+    }
+
+    public static class ImageUrl {
+
+        public static final String imageId = "이미지의 Id";
+        public static final String imageUrl = "이미지의 S3 URL";
+    }
+
+}

--- a/src/main/java/grimuri/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/grimuri/backend/global/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package grimuri.backend.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "GrimUri Backend API Docs",
+                description = "KHU-CSE 2023학년도 1학기 캡스톤디자인 GrimUri",
+                version = "v1"
+        )
+)
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi grimUriOpenApi() {
+        String[] paths = {"/api/v1/**"};
+
+        return GroupedOpenApi.builder()
+                .group("GrimUri API v1")
+                .pathsToMatch(paths)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,19 @@
 server:
-  servlet:
-    context-path: /api/v1
+  error:
+    include-message: always
+
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    groups-order: desc
+    operations-sorter: method
+    disable-swagger-default-url: true
+    display-request-duration: true
+  api-docs:
+    path: /api-docs
+  show-actuator: false
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  paths-to-match:
+    - /api/v1/**


### PR DESCRIPTION
## 주요사항

### DiaryController
해당 클래스를 인터페이스화하여, 인터페이스에 Swagger 관련 코드를 작성하였음.
구현 클래스를 분리하여 컨트롤러 로직을 작성함.
### Schema
기존 DTO와 컨트롤러의 Parameter, PathVariable 등에 스키마 정의함.

## Issue

### Page Response
Page 내부의 content에 대한 스키마 정의에 실패함.