### PR TITLE
[Resolves #59] DB에서 후보 이미지 삭제 안되는 현상

### DIFF
--- a/src/main/java/grimuri/backend/domain/diary/Diary.java
+++ b/src/main/java/grimuri/backend/domain/diary/Diary.java
@@ -35,7 +35,7 @@ public class Diary extends BaseTimeEntity {
     @Column(nullable = true)
     private String shortContent;
 
-    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "diary")
     @BatchSize(size = 10)
     private List<Image> imageList = new ArrayList<>();
 

--- a/src/main/java/grimuri/backend/domain/diary/service/DiaryService.java
+++ b/src/main/java/grimuri/backend/domain/diary/service/DiaryService.java
@@ -87,6 +87,7 @@ public class DiaryService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "User의 Diary가 아닙니다.");
         }
 
+        imageRepository.deleteAllByDiary(findDiary);
         diaryRepository.delete(findDiary);
     }
     

--- a/src/main/java/grimuri/backend/domain/image/ImageRepository.java
+++ b/src/main/java/grimuri/backend/domain/image/ImageRepository.java
@@ -1,5 +1,6 @@
 package grimuri.backend.domain.image;
 
+import grimuri.backend.domain.diary.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,6 +8,8 @@ import java.util.List;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    void deleteAllByDiary(Diary diary);
 
     List<Image> findByDiaryId(Long diaryId);
 


### PR DESCRIPTION
#59
- 일기 삭제 로직 수정. cascade 옵션 대신 Repository 통해 후보이미지 삭제